### PR TITLE
fixing order by 'from' to 'starts_at' 

### DIFF
--- a/app/controllers/refinery/calendar/admin/events_controller.rb
+++ b/app/controllers/refinery/calendar/admin/events_controller.rb
@@ -7,7 +7,7 @@ module Refinery
         crudify :'refinery/calendar/event',
                 :xhr_paging => true,
                 :sortable => false,
-                :order => "'from' DESC"
+                :order => "starts_at DESC"
 
         private
         def find_venues


### PR DESCRIPTION
minor change to fix Refinery::Calendar::Admin::EventsController 
