### PR TITLE
Invoke find_page method

### DIFF
--- a/app/controllers/refinery/calendar/events_controller.rb
+++ b/app/controllers/refinery/calendar/events_controller.rb
@@ -1,6 +1,8 @@
 module Refinery
   module Calendar
     class EventsController < ::ApplicationController
+      before_filter :find_page, :except => :archive
+
       def index
         @events = Event.upcoming.order('refinery_calendar_events.starts_at DESC')
 


### PR DESCRIPTION
It looks like the events controller is missing the call to actually run the before_filter so `@page` is undefined and crashes the view if you try to use something like `@page.content_for(:body)` in your templates.
